### PR TITLE
use callback ref

### DIFF
--- a/example/src/domain/App.js
+++ b/example/src/domain/App.js
@@ -1,9 +1,8 @@
-import { useElementSize }  from '@kaliber/use-element-size'
+import { useElementSize } from '@kaliber/use-element-size'
 import styles from './App.css'
 
 export default function App() {
-  const elementRef = React.useRef(null)
-  const { width, height } = useElementSize(elementRef)
+  const { size: { width, height }, ref: elementRef } = useElementSize()
   const [expanded, setExpanded] = React.useState(false)
 
   return (
@@ -30,8 +29,7 @@ export default function App() {
 }
 
 export function Expand({ children, expanded }) {
-  const innerRef = React.useRef(null)
-  const { height } = useElementSize(innerRef)
+  const { size: { height }, ref: innerRef } = useElementSize()
 
   return (
     <div className={styles.componentExpand} style={{ height: (expanded ? height : 0) + 'px' }}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,28 @@
 // assumes the resize-observer-polyfill is loaded, this can be done through polyfill.io
-export function useElementSize(elementRef) {
+export function useElementSize() {
+
   const [size, setSize] = React.useState({ width: 0, height: 0 })
   const observerRef = React.useRef(null)
+  const targetRef = React.useRef(null)
 
-  React.useEffect(
-    () => {
+  React.useEffect(() => cleanup, [])
+
+  const ref = React.useCallback(
+    node => {
       // @ts-ignore
-      observerRef.current = new window.ResizeObserver(callback)
-      return () => { observerRef.current.disconnect() }
+      if (!observerRef.current) observerRef.current = new window.ResizeObserver(callback)
+      if (targetRef.current) observerRef.current.unobserve(targetRef.current)
+      targetRef.current = node
+      if (node) observerRef.current.observe(node)
     },
     []
   )
 
-  React.useEffect(
-    () => {
-      const element = elementRef.current
-      observerRef.current.observe(element)
-      return () => { observerRef.current.unobserve(element) }
-    },
-    [elementRef]
-  )
+  return { size, ref }
 
-  return size
+  function cleanup() {
+    if (observerRef.current) observerRef.current.disconnect()
+  }
 
   function callback([entry]) {
     setSize({ width: entry.contentRect.width, height: entry.contentRect.height })


### PR DESCRIPTION
Erik kwam er achter dat we niet de juiste `ref` gebruiken om DOM elementen uit te lezen. We zouden een callback ref moeten gebruiken om zeker te weten dat we het juiste element blijven uit lezen.

Meer info:
https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
https://reactjs.org/docs/refs-and-the-dom.html#callback-refs

We zullen ook de code van  [use-is-intersecting](https://github.com/kaliberjs/use-is-intersecting) aan moeten passen.