### PR TITLE
Check if borderboxsize is iterator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export function useElementSize() {
 }
 
 function getSizeFromEntry(entry) {
-  if (entry.borderBoxSize) {
+  if (entry.borderBoxSize && entry.borderBoxSize[Symbol.iterator] === 'function') {
     const [{ inlineSize: width, blockSize: height }] = entry.borderBoxSize
     return { width, height }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,11 @@ export function useElementSize() {
 }
 
 function getSizeFromEntry(entry) {
-  if (entry.borderBoxSize && entry.borderBoxSize[Symbol.iterator] === 'function') {
+  if (entry.borderBoxSize && Array.isArray(entry.borderBoxSize)) {
     const [{ inlineSize: width, blockSize: height }] = entry.borderBoxSize
+    return { width, height }
+  } else if (entry.contentRect && entry.contentRect instanceof DOMRectReadOnly) {
+    const { width, height } = entry.contentRect
     return { width, height }
   }
 


### PR DESCRIPTION
Ik weet niet of dit de juiste fix is, maar techlab krijgt nogal wat errors sinds we use-element-size is geupdate. 

Lijkt erop alleen in Samsung browser fout te gaan.

